### PR TITLE
#23 - Extracted Version class with normalize() method

### DIFF
--- a/src/main/java/com/artpie/nuget/Nuspec.java
+++ b/src/main/java/com/artpie/nuget/Nuspec.java
@@ -60,11 +60,19 @@ public final class Nuspec {
      * @throws IOException In case exception occurred on reading document.
      */
     public PackageIdentity identity() throws IOException {
-        final XML xml = this.xml()
-            .registerNs("ns", "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd");
-        final String id = single(xml, "/ns:package/ns:metadata/ns:id/text()");
-        final String version = single(xml, "/ns:package/ns:metadata/ns:version/text()");
-        return new PackageIdentity(id, version);
+        final String id = single(this.xml(), "/ns:package/ns:metadata/ns:id/text()");
+        return new PackageIdentity(id, this.version());
+    }
+
+    /**
+     * Extract version from document.
+     *
+     * @return Package version.
+     * @throws IOException In case exception occurred on reading document.
+     */
+    public Version version() throws IOException {
+        final String version = single(this.xml(), "/ns:package/ns:metadata/ns:version/text()");
+        return new Version(version);
     }
 
     /**
@@ -84,7 +92,8 @@ public final class Nuspec {
      * @throws IOException In case exception occurred on reading document.
      */
     private XML xml() throws IOException {
-        return new XMLDocument(new ByteArrayInputStream(this.content.read()));
+        return new XMLDocument(new ByteArrayInputStream(this.content.read()))
+            .registerNs("ns", "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd");
     }
 
     /**

--- a/src/main/java/com/artpie/nuget/PackageIdentity.java
+++ b/src/main/java/com/artpie/nuget/PackageIdentity.java
@@ -42,7 +42,7 @@ public final class PackageIdentity {
     /**
      * Package version.
      */
-    private final String version;
+    private final Version version;
 
     /**
      * Ctor.
@@ -50,7 +50,7 @@ public final class PackageIdentity {
      * @param id Package identity.
      * @param version Package version.
      */
-    public PackageIdentity(final String id, final String version) {
+    public PackageIdentity(final String id, final Version version) {
         this.id = id;
         this.version = version;
     }
@@ -63,7 +63,7 @@ public final class PackageIdentity {
     public Key nupkgKey() {
         return new Key.From(
             this.root(),
-            String.format("%s.%s.nupkg", this.idLowerCase(), this.version)
+            String.format("%s.%s.nupkg", this.idLowerCase(), this.version.normalized())
         );
     }
 
@@ -75,7 +75,7 @@ public final class PackageIdentity {
     public Key hashKey() {
         return new Key.From(
             this.root(),
-            String.format("%s.%s.nupkg.sha512", this.idLowerCase(), this.version)
+            String.format("%s.%s.nupkg.sha512", this.idLowerCase(), this.version.normalized())
         );
     }
 
@@ -94,7 +94,7 @@ public final class PackageIdentity {
      * @return Root key.
      */
     private Key root() {
-        return new Key.From(this.idLowerCase(), this.version);
+        return new Key.From(this.idLowerCase(), this.version.normalized());
     }
 
     /**

--- a/src/main/java/com/artpie/nuget/Version.java
+++ b/src/main/java/com/artpie/nuget/Version.java
@@ -28,7 +28,7 @@ package com.artpie.nuget;
  * Version of package.
  * See <a href="https://docs.microsoft.com/en-us/nuget/concepts/package-versioning">Package versioning</a>.
  *
- * @todo: normalized() method should actually do normalization as described in docs
+ * @todo: normalized() method should actually do normalization as described in docs, see https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#normalized-version-numbers
  * @since 0.1
  */
 public final class Version {

--- a/src/main/java/com/artpie/nuget/Version.java
+++ b/src/main/java/com/artpie/nuget/Version.java
@@ -24,46 +24,36 @@
 
 package com.artpie.nuget;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
-
 /**
- * Tests for {@link PackageIdentity}.
+ * Version of package.
+ * See <a href="https://docs.microsoft.com/en-us/nuget/concepts/package-versioning">Package versioning</a>.
  *
+ * @todo: normalized() method should actually do normalization as described in docs
  * @since 0.1
  */
-public class PackageIdentityTest {
+public final class Version {
 
     /**
-     * Example package identity.
+     * Raw version string.
      */
-    private final PackageIdentity identity = new PackageIdentity(
-        "Newtonsoft.Json",
-        new Version("12.0.3")
-    );
+    private final String raw;
 
-    @Test
-    void shouldGenerateNupkgKey() {
-        MatcherAssert.assertThat(
-            this.identity.nupkgKey().string(),
-            Matchers.is("newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg")
-        );
+    /**
+     * Ctor.
+     *
+     * @param raw Raw version string.
+     */
+    public Version(final String raw) {
+        this.raw = raw;
     }
 
-    @Test
-    void shouldGenerateHashKey() {
-        MatcherAssert.assertThat(
-            this.identity.hashKey().string(),
-            Matchers.is("newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg.sha512")
-        );
-    }
-
-    @Test
-    void shouldGenerateNuspecKey() {
-        MatcherAssert.assertThat(
-            this.identity.nuspecKey().string(),
-            Matchers.is("newtonsoft.json/12.0.3/newtonsoft.json.nuspec")
-        );
+    /**
+     * Get normalized version.
+     * See <a href="https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#normalized-version-numbers">Normalized version numbers</a>.
+     *
+     * @return Normalized version string.
+     */
+    public String normalized() {
+        return this.raw;
     }
 }

--- a/src/test/java/com/artpie/nuget/HashTest.java
+++ b/src/test/java/com/artpie/nuget/HashTest.java
@@ -49,7 +49,7 @@ class HashTest {
         final BlockingStorage storage = new BlockingStorage(new FileStorage(temp));
         new Hash(HashCode.fromString("0123456789abcdef")).save(
             storage,
-            new PackageIdentity(id, version)
+            new PackageIdentity(id, new Version(version))
         );
         MatcherAssert.assertThat(
             storage.value(new Key.From(id, version, "abc.0.0.1.nupkg.sha512")),

--- a/src/test/java/com/artpie/nuget/NupkgTest.java
+++ b/src/test/java/com/artpie/nuget/NupkgTest.java
@@ -59,7 +59,7 @@ class NupkgTest {
         final String id = "newtonsoft.json";
         final String version = "12.0.3";
         new Nupkg(ByteSource.wrap(new NewtonJsonResource(this.name).bytes()))
-            .save(storage, new PackageIdentity(id, version));
+            .save(storage, new PackageIdentity(id, new Version(version)));
         MatcherAssert.assertThat(
             storage.value(new Key.From(id, version, this.name)),
             Matchers.equalTo(new NewtonJsonResource(this.name).bytes())
@@ -69,7 +69,7 @@ class NupkgTest {
     @Test
     void shouldCalculateHash(final @TempDir Path temp) throws Exception {
         final BlockingStorage storage = new BlockingStorage(new FileStorage(temp));
-        final PackageIdentity identity = new PackageIdentity("foo", "1.0.0");
+        final PackageIdentity identity = new PackageIdentity("foo", new Version("1.0.0"));
         new Nupkg(ByteSource.wrap("test data".getBytes(StandardCharsets.UTF_8)))
             .hash()
             .save(storage, identity);

--- a/src/test/java/com/artpie/nuget/NuspecTest.java
+++ b/src/test/java/com/artpie/nuget/NuspecTest.java
@@ -24,7 +24,6 @@
 
 package com.artpie.nuget;
 
-import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
 import com.google.common.io.ByteSource;
@@ -59,6 +58,15 @@ class NuspecTest {
     }
 
     @Test
+    void shouldExtractVersion() throws Exception {
+        final Version version = this.nuspec.version();
+        MatcherAssert.assertThat(
+            version.normalized(),
+            Matchers.equalTo("12.0.3")
+        );
+    }
+
+    @Test
     void shouldExtractIdentity() throws Exception {
         final PackageIdentity identity = this.nuspec.identity();
         MatcherAssert.assertThat(
@@ -71,9 +79,8 @@ class NuspecTest {
     void shouldSave(final @TempDir Path temp) throws Exception {
         final BlockingStorage storage = new BlockingStorage(new FileStorage(temp));
         this.nuspec.save(storage);
-        final Key.From key = new Key.From("newtonsoft.json", "12.0.3", this.name);
         MatcherAssert.assertThat(
-            storage.value(key),
+            storage.value(this.nuspec.identity().nuspecKey()),
             Matchers.equalTo(new NewtonJsonResource(this.name).bytes())
         );
     }


### PR DESCRIPTION
Issue: https://github.com/artipie/nuget-adapter/issues/23
This PR is targeted to extract Versionc lass from PackageIdentity and adds normalize() method, but without proper implementation