### PR TITLE
#20 - Throw InvalidPackageException from Repository.add() when packag…

### DIFF
--- a/src/main/java/com/artpie/nuget/InvalidPackageException.java
+++ b/src/main/java/com/artpie/nuget/InvalidPackageException.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artpie.nuget;
+
+/**
+ * Exception indicates that package is invalid and so cannot be handled by repository.
+ *
+ * @since 0.1
+ */
+public final class InvalidPackageException extends Exception {
+    private static final long serialVersionUID = -1;
+
+    /**
+     * Ctor.
+     *
+     * @param cause Underlying cause for package being invalid.
+     */
+    public InvalidPackageException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/artpie/nuget/InvalidPackageException.java
+++ b/src/main/java/com/artpie/nuget/InvalidPackageException.java
@@ -28,9 +28,8 @@ package com.artpie.nuget;
  *
  * @since 0.1
  */
+@SuppressWarnings("serial")
 public final class InvalidPackageException extends Exception {
-    private static final long serialVersionUID = -1;
-
     /**
      * Ctor.
      *

--- a/src/main/java/com/artpie/nuget/Repository.java
+++ b/src/main/java/com/artpie/nuget/Repository.java
@@ -55,11 +55,18 @@ public class Repository {
      *
      * @param key Key to find content of .nupkg package.
      * @throws IOException In case exception occurred on operations with storage.
+     * @throws InvalidPackageException If package content is invalid and so cannot be added.
      */
-    public void add(final Key key) throws IOException {
+    public void add(final Key key) throws IOException, InvalidPackageException {
         final NuGetPackage nupkg = new Nupkg(ByteSource.wrap(this.storage.value(key)));
-        final Nuspec nuspec = nupkg.nuspec();
-        final PackageIdentity id = nuspec.identity();
+        final Nuspec nuspec;
+        final PackageIdentity id;
+        try {
+            nuspec = nupkg.nuspec();
+            id = nuspec.identity();
+        } catch (final IOException | IllegalArgumentException ex) {
+            throw new InvalidPackageException(ex);
+        }
         nupkg.save(this.storage, id);
         nupkg.hash().save(this.storage, id);
         nuspec.save(this.storage);

--- a/src/test/java/com/artpie/nuget/RepositoryTest.java
+++ b/src/test/java/com/artpie/nuget/RepositoryTest.java
@@ -30,6 +30,7 @@ import com.artipie.asto.fs.FileStorage;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -73,6 +74,18 @@ class RepositoryTest {
         MatcherAssert.assertThat(
             storage.value(new Key.From(root, nuspec)),
             Matchers.equalTo(new NewtonJsonResource(nuspec).bytes())
+        );
+    }
+
+    @Test
+    void shouldFailToAddInvalidPackage() {
+        final BlockingStorage storage = new BlockingStorage(new FileStorage(this.temp));
+        final Key.From source = new Key.From("invalid");
+        storage.save(source, "not a zip".getBytes());
+        final Repository repository = new Repository(storage);
+        Assertions.assertThrows(
+            InvalidPackageException.class,
+            () -> repository.add(source)
         );
     }
 }

--- a/src/test/java/com/artpie/nuget/RepositoryTest.java
+++ b/src/test/java/com/artpie/nuget/RepositoryTest.java
@@ -85,7 +85,9 @@ class RepositoryTest {
         final Repository repository = new Repository(storage);
         Assertions.assertThrows(
             InvalidPackageException.class,
-            () -> repository.add(source)
+            () -> repository.add(source),
+            // @checkstyle LineLengthCheck (1 line)
+            "Repository expected to throw InvalidPackageException if package is invalid and cannot be added"
         );
     }
 }


### PR DESCRIPTION
Part of implementation of issue #20 
Added checked exception for case when package being added to Repository is invalid.
By spec it is required to return HTTP code 400 when package failed to be added because of being invalid