### PR TITLE
#19 - NuGet slice skeleton with basic routing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@ SOFTWARE.
       <version>0.22.2</version>
     </dependency>
     <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>http</artifactId>
+      <version>0.2.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/src/main/java/com/artpie/nuget/http/NuGet.java
+++ b/src/main/java/com/artpie/nuget/http/NuGet.java
@@ -27,6 +27,7 @@ import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsWithStatus;
+import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.Flow;
@@ -35,7 +36,6 @@ import java.util.concurrent.Flow;
  * NuGet repository HTTP front end.
  *
  * @since 0.1
- * @todo #19:30min Replace HTTP status magic numbers.
  */
 public final class NuGet implements Slice {
 
@@ -67,12 +67,10 @@ public final class NuGet implements Slice {
             if (request.method().equals("GET")) {
                 response = resource.get();
             } else {
-                final int notallowed = 405;
-                response = new RsWithStatus(notallowed);
+                response = new RsWithStatus(HttpURLConnection.HTTP_BAD_METHOD);
             }
         } else {
-            final int notfound = 404;
-            response = new RsWithStatus(notfound);
+            response = new RsWithStatus(HttpURLConnection.HTTP_NOT_FOUND);
         }
         return response;
     }

--- a/src/main/java/com/artpie/nuget/http/NuGet.java
+++ b/src/main/java/com/artpie/nuget/http/NuGet.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artpie.nuget.http;
+
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.http.rs.RsWithStatus;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.Flow;
+
+/**
+ * NuGet repository HTTP front end.
+ *
+ * @since 0.1
+ */
+public final class NuGet implements Slice {
+
+    /**
+     * Base path.
+     */
+    private final String base;
+
+    /**
+     * Ctor.
+     *
+     * @param base Base path.
+     */
+    public NuGet(final String base) {
+        this.base = base;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Flow.Publisher<ByteBuffer> body
+    ) {
+        final Response response;
+        final RequestLineFrom request = new RequestLineFrom(line);
+        final String path = request.uri().getPath();
+        if (path.startsWith(this.base)) {
+            final Resource resource = new PackageContent();
+            if (request.method().equals("GET")) {
+                response = resource.get();
+            } else {
+                final int notallowed = 405;
+                response = new RsWithStatus(notallowed);
+            }
+        } else {
+            final int notfound = 404;
+            response = new RsWithStatus(notfound);
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/artpie/nuget/http/NuGet.java
+++ b/src/main/java/com/artpie/nuget/http/NuGet.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Flow;
  * NuGet repository HTTP front end.
  *
  * @since 0.1
+ * @todo #19:30min Replace HTTP status magic numbers.
  */
 public final class NuGet implements Slice {
 

--- a/src/main/java/com/artpie/nuget/http/PackageContent.java
+++ b/src/main/java/com/artpie/nuget/http/PackageContent.java
@@ -1,0 +1,39 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artpie.nuget.http;
+
+import com.artipie.http.Response;
+
+/**
+ * Package content resource.
+ * See <a href="https://docs.microsoft.com/en-us/nuget/api/package-base-address-resource">Package Content</a>
+ *
+ * @since 0.1
+ */
+public final class PackageContent implements Resource {
+    @Override
+    public Response get() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/artpie/nuget/http/Resource.java
+++ b/src/main/java/com/artpie/nuget/http/Resource.java
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artpie.nuget.http;
+
+import com.artipie.http.Response;
+
+/**
+ * Resource serving HTTP requests.
+ *
+ * @since 0.1
+ */
+public interface Resource {
+    /**
+     * Serve GET method.
+     *
+     * @return Response to request.
+     */
+    Response get();
+}

--- a/src/main/java/com/artpie/nuget/http/package-info.java
+++ b/src/main/java/com/artpie/nuget/http/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * NuGet repository HTTP front end.
+ *
+ * @since 0.1
+ */
+package com.artpie.nuget.http;

--- a/src/test/java/com/artpie/nuget/http/NuGetTest.java
+++ b/src/test/java/com/artpie/nuget/http/NuGetTest.java
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artpie.nuget.http;
+
+import com.artipie.http.Response;
+import com.artipie.http.hm.RsHasStatus;
+import io.reactivex.Flowable;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.FlowAdapters;
+
+/**
+ * Tests for {@link NuGet}.
+ *
+ * @since 0.1
+ */
+class NuGetTest {
+
+    /**
+     * Tested NuGet slice.
+     */
+    private NuGet nuget;
+
+    @BeforeEach
+    void init() {
+        this.nuget = new NuGet("/base/");
+    }
+
+    @Test
+    void shouldFailGetPackageContentFromNotBasePath() {
+        final Response response = this.nuget.response(
+            "GET /not-base/package/1.0.0/content.nupkg",
+            Collections.emptyList(),
+            FlowAdapters.toFlowPublisher(Flowable.empty())
+        );
+        final int notfound = 404;
+        MatcherAssert.assertThat(response, new RsHasStatus(notfound));
+    }
+
+    @Test
+    void shouldFailPutPackageContent() {
+        final Response response = this.nuget.response(
+            "PUT /base/package/1.0.0/content.nupkg",
+            Collections.emptyList(),
+            FlowAdapters.toFlowPublisher(Flowable.empty())
+        );
+        final int notallowed = 405;
+        MatcherAssert.assertThat(response, new RsHasStatus(notallowed));
+    }
+}

--- a/src/test/java/com/artpie/nuget/http/NuGetTest.java
+++ b/src/test/java/com/artpie/nuget/http/NuGetTest.java
@@ -26,6 +26,7 @@ package com.artpie.nuget.http;
 import com.artipie.http.Response;
 import com.artipie.http.hm.RsHasStatus;
 import io.reactivex.Flowable;
+import java.net.HttpURLConnection;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,6 @@ import org.reactivestreams.FlowAdapters;
  * Tests for {@link NuGet}.
  *
  * @since 0.1
- * @todo #19:30min Replace HTTP status magic numbers.
  */
 class NuGetTest {
 
@@ -57,11 +57,10 @@ class NuGetTest {
             Collections.emptyList(),
             FlowAdapters.toFlowPublisher(Flowable.empty())
         );
-        final int notfound = 404;
         MatcherAssert.assertThat(
             "Resources from outside of base path should not be found",
             response,
-            new RsHasStatus(notfound)
+            new RsHasStatus(HttpURLConnection.HTTP_NOT_FOUND)
         );
     }
 
@@ -72,11 +71,10 @@ class NuGetTest {
             Collections.emptyList(),
             FlowAdapters.toFlowPublisher(Flowable.empty())
         );
-        final int notallowed = 405;
         MatcherAssert.assertThat(
             "Package content cannot be put",
             response,
-            new RsHasStatus(notallowed)
+            new RsHasStatus(HttpURLConnection.HTTP_BAD_METHOD)
         );
     }
 }

--- a/src/test/java/com/artpie/nuget/http/NuGetTest.java
+++ b/src/test/java/com/artpie/nuget/http/NuGetTest.java
@@ -57,7 +57,11 @@ class NuGetTest {
             FlowAdapters.toFlowPublisher(Flowable.empty())
         );
         final int notfound = 404;
-        MatcherAssert.assertThat(response, new RsHasStatus(notfound));
+        MatcherAssert.assertThat(
+            "Resources from outside of base path should not be found",
+            response,
+            new RsHasStatus(notfound)
+        );
     }
 
     @Test
@@ -68,6 +72,10 @@ class NuGetTest {
             FlowAdapters.toFlowPublisher(Flowable.empty())
         );
         final int notallowed = 405;
-        MatcherAssert.assertThat(response, new RsHasStatus(notallowed));
+        MatcherAssert.assertThat(
+            "Package content cannot be put",
+            response,
+            new RsHasStatus(notallowed)
+        );
     }
 }

--- a/src/test/java/com/artpie/nuget/http/NuGetTest.java
+++ b/src/test/java/com/artpie/nuget/http/NuGetTest.java
@@ -36,6 +36,7 @@ import org.reactivestreams.FlowAdapters;
  * Tests for {@link NuGet}.
  *
  * @since 0.1
+ * @todo #19:30min Replace HTTP status magic numbers.
  */
 class NuGetTest {
 

--- a/src/test/java/com/artpie/nuget/http/package-info.java
+++ b/src/test/java/com/artpie/nuget/http/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * NuGet repository HTTP front end.
+ *
+ * @since 0.1
+ */
+package com.artpie.nuget.http;


### PR DESCRIPTION
Part of issue #19
Adds NuGet slice with basic routing to PackageContent resource, which is going to be used to access package content when nuget installs a package