### PR TITLE
#20 - Throw PackageVersionAlreadyExistsException from Repository.add()

### DIFF
--- a/src/main/java/com/artpie/nuget/PackageId.java
+++ b/src/main/java/com/artpie/nuget/PackageId.java
@@ -66,4 +66,9 @@ public final class PackageId {
     public Key versionsKey() {
         return new Key.From(this.lower(), "index.json");
     }
+
+    @Override
+    public String toString() {
+        return this.raw;
+    }
 }

--- a/src/main/java/com/artpie/nuget/PackageIdentity.java
+++ b/src/main/java/com/artpie/nuget/PackageIdentity.java
@@ -61,7 +61,7 @@ public final class PackageIdentity {
      */
     public Key nupkgKey() {
         return new Key.From(
-            this.root(),
+            this.rootKey(),
             String.format("%s.%s.nupkg", this.id.lower(), this.version.normalized())
         );
     }
@@ -73,7 +73,7 @@ public final class PackageIdentity {
      */
     public Key hashKey() {
         return new Key.From(
-            this.root(),
+            this.rootKey(),
             String.format("%s.%s.nupkg.sha512", this.id.lower(), this.version.normalized())
         );
     }
@@ -84,7 +84,7 @@ public final class PackageIdentity {
      * @return Key to .nuspec file.
      */
     public Key nuspecKey() {
-        return new Key.From(this.root(), String.format("%s.nuspec", this.id.lower()));
+        return new Key.From(this.rootKey(), String.format("%s.nuspec", this.id.lower()));
     }
 
     /**
@@ -92,7 +92,7 @@ public final class PackageIdentity {
      *
      * @return Root key.
      */
-    private Key root() {
+    public Key rootKey() {
         return new Key.From(this.id.lower(), this.version.normalized());
     }
 }

--- a/src/main/java/com/artpie/nuget/PackageIdentity.java
+++ b/src/main/java/com/artpie/nuget/PackageIdentity.java
@@ -95,4 +95,9 @@ public final class PackageIdentity {
     public Key rootKey() {
         return new Key.From(this.id.lower(), this.version.normalized());
     }
+
+    @Override
+    public String toString() {
+        return String.format("Package: '%s' Version: '%s'", this.id, this.version);
+    }
 }

--- a/src/main/java/com/artpie/nuget/PackageVersionAlreadyExistsException.java
+++ b/src/main/java/com/artpie/nuget/PackageVersionAlreadyExistsException.java
@@ -31,4 +31,13 @@ package com.artpie.nuget;
  */
 @SuppressWarnings("serial")
 public final class PackageVersionAlreadyExistsException extends Exception {
+
+    /**
+     * Ctor.
+     *
+     * @param message Exception details message.
+     */
+    public PackageVersionAlreadyExistsException(final String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/artpie/nuget/PackageVersionAlreadyExistsException.java
+++ b/src/main/java/com/artpie/nuget/PackageVersionAlreadyExistsException.java
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artpie.nuget;
+
+/**
+ * Exception indicates that package version cannot be added,
+ * because it is already exists in the storage.
+ *
+ * @since 0.1
+ */
+@SuppressWarnings("serial")
+public final class PackageVersionAlreadyExistsException extends Exception {
+}

--- a/src/main/java/com/artpie/nuget/Repository.java
+++ b/src/main/java/com/artpie/nuget/Repository.java
@@ -56,8 +56,10 @@ public final class Repository {
      * @param key Key to find content of .nupkg package.
      * @throws IOException In case exception occurred on operations with storage.
      * @throws InvalidPackageException If package content is invalid and so cannot be added.
+     * @throws PackageVersionAlreadyExistsException If package version already in storage.
      */
-    public void add(final Key key) throws IOException, InvalidPackageException {
+    public void add(final Key key)
+        throws IOException, InvalidPackageException, PackageVersionAlreadyExistsException {
         final NuGetPackage nupkg = new Nupkg(ByteSource.wrap(this.storage.value(key)));
         final Nuspec nuspec;
         final PackageIdentity id;
@@ -66,6 +68,9 @@ public final class Repository {
             id = nuspec.identity();
         } catch (final IOException | IllegalArgumentException ex) {
             throw new InvalidPackageException(ex);
+        }
+        if (!this.storage.list(id.rootKey()).isEmpty()) {
+            throw new PackageVersionAlreadyExistsException();
         }
         nupkg.save(this.storage, id);
         nupkg.hash().save(this.storage, id);

--- a/src/main/java/com/artpie/nuget/Repository.java
+++ b/src/main/java/com/artpie/nuget/Repository.java
@@ -70,7 +70,7 @@ public final class Repository {
             throw new InvalidPackageException(ex);
         }
         if (!this.storage.list(id.rootKey()).isEmpty()) {
-            throw new PackageVersionAlreadyExistsException();
+            throw new PackageVersionAlreadyExistsException(id.toString());
         }
         nupkg.save(this.storage, id);
         nupkg.hash().save(this.storage, id);

--- a/src/main/java/com/artpie/nuget/Version.java
+++ b/src/main/java/com/artpie/nuget/Version.java
@@ -94,6 +94,11 @@ public final class Version {
         return builder.toString();
     }
 
+    @Override
+    public String toString() {
+        return this.raw;
+    }
+
     /**
      * Get RegEx matcher by version pattern.
      *

--- a/src/test/java/com/artpie/nuget/PackageIdentityTest.java
+++ b/src/test/java/com/artpie/nuget/PackageIdentityTest.java
@@ -44,6 +44,14 @@ public class PackageIdentityTest {
     );
 
     @Test
+    void shouldGenerateRootKey() {
+        MatcherAssert.assertThat(
+            this.identity.rootKey().string(),
+            Matchers.is("newtonsoft.json/12.0.3")
+        );
+    }
+
+    @Test
     void shouldGenerateNupkgKey() {
         MatcherAssert.assertThat(
             this.identity.nupkgKey().string(),


### PR DESCRIPTION
Part of issue #20 
Added checked exception to Repository.add() for case when package version already exists, as it is required by spec to return special HTTP code in this case.