### PR TITLE
#29 - Tests coverage for getting package enumeration versions

### DIFF
--- a/src/test/java/com/artpie/nuget/http/NuGetTest.java
+++ b/src/test/java/com/artpie/nuget/http/NuGetTest.java
@@ -35,6 +35,7 @@ import io.reactivex.Flowable;
 import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -144,5 +145,50 @@ class NuGetTest {
             Flowable.empty()
         );
         MatcherAssert.assertThat(response, new RsHasStatus(RsStatus.METHOD_NOT_ALLOWED));
+    }
+
+    @Test
+    void shouldGetPackageVersions() {
+        final byte[] data = "example".getBytes();
+        new BlockingStorage(this.storage).save(
+            new Key.From("package2", "index.json"),
+            data
+        );
+        MatcherAssert.assertThat(
+            this.nuget.response(
+                "GET /base/package2/index.json",
+                Collections.emptyList(),
+                Flowable.empty()
+            ),
+            Matchers.allOf(
+                new RsHasStatus(RsStatus.OK),
+                new RsHasBody(data)
+            )
+        );
+    }
+
+    @Test
+    void shouldFailGetPackageVersionsWhenNotExists() {
+        MatcherAssert.assertThat(
+            this.nuget.response(
+                "GET /base/unknown-package/index.json",
+                Collections.emptyList(),
+                Flowable.empty()
+            ),
+            new RsHasStatus(RsStatus.NOT_FOUND)
+        );
+    }
+
+    @Test
+    void shouldFailPutPackageVersions() {
+        final Response response = this.nuget.response(
+            "PUT /base/package2/index.json",
+            Collections.emptyList(),
+            Flowable.empty()
+        );
+        MatcherAssert.assertThat(
+            response,
+            new RsHasStatus(RsStatus.METHOD_NOT_ALLOWED)
+        );
     }
 }

--- a/src/test/java/com/artpie/nuget/http/NuGetTest.java
+++ b/src/test/java/com/artpie/nuget/http/NuGetTest.java
@@ -196,19 +196,6 @@ class NuGetTest {
         );
     }
 
-    @Test
-    void shouldFailPutPackageVersions() {
-        final Response response = this.nuget.response(
-            "PUT /base/package2/index.json",
-            Collections.emptyList(),
-            Flowable.empty()
-        );
-        MatcherAssert.assertThat(
-            response,
-            new RsHasStatus(RsStatus.METHOD_NOT_ALLOWED)
-        );
-    }
-
     private static Flowable<ByteBuffer> nupkg() throws Exception {
         final URL resource = Thread.currentThread().getContextClassLoader()
             .getResource("newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg");


### PR DESCRIPTION
Closes issue #29 
Added tests to cover getting package versions via HTTP. The implementation is already there, versions list is stored in Storage and served the same way as package content.