### PR TITLE
#19 - Bug fix for packages with no versions

### DIFF
--- a/src/main/java/com/artpie/nuget/http/metadata/Registration.java
+++ b/src/main/java/com/artpie/nuget/http/metadata/Registration.java
@@ -110,6 +110,14 @@ class Registration implements Resource {
      */
     private List<RegistrationPage> pages() throws IOException {
         final List<Version> versions = this.repository.versions(this.id).all();
-        return Collections.singletonList(new RegistrationPage(this.repository, this.id, versions));
+        final List<RegistrationPage> pages;
+        if (versions.isEmpty()) {
+            pages = Collections.emptyList();
+        } else {
+            pages = Collections.singletonList(
+                new RegistrationPage(this.repository, this.id, versions)
+            );
+        }
+        return pages;
     }
 }

--- a/src/main/java/com/artpie/nuget/http/metadata/RegistrationPage.java
+++ b/src/main/java/com/artpie/nuget/http/metadata/RegistrationPage.java
@@ -80,6 +80,9 @@ final class RegistrationPage {
      * @throws IOException In case exception occurred on reading data from repository.
      */
     public JsonObject json() throws IOException {
+        if (this.versions.isEmpty()) {
+            throw new IllegalArgumentException("No versions in the page");
+        }
         final Version lower = this.versions.get(0);
         final Version upper = this.versions.get(this.versions.size() - 1);
         final JsonArrayBuilder items = Json.createArrayBuilder();

--- a/src/main/java/com/artpie/nuget/http/metadata/RegistrationPage.java
+++ b/src/main/java/com/artpie/nuget/http/metadata/RegistrationPage.java
@@ -81,7 +81,9 @@ final class RegistrationPage {
      */
     public JsonObject json() throws IOException {
         if (this.versions.isEmpty()) {
-            throw new IllegalArgumentException("No versions in the page");
+            throw new IllegalStateException(
+                String.format("Registration page contains no versions: '%s'", this.id)
+            );
         }
         final Version lower = this.versions.get(0);
         final Version upper = this.versions.get(this.versions.size() - 1);

--- a/src/test/java/com/artpie/nuget/http/metadata/NuGetPackageMetadataTest.java
+++ b/src/test/java/com/artpie/nuget/http/metadata/NuGetPackageMetadataTest.java
@@ -115,6 +115,24 @@ class NuGetPackageMetadataTest {
     }
 
     @Test
+    void shouldGetRegistrationsWhenEmpty() {
+        final Response response = this.nuget.response(
+            "GET /base/registrations/my.lib/index.json",
+            Collections.emptyList(),
+            Flowable.empty()
+        );
+        MatcherAssert.assertThat(
+            response,
+            new AllOf<>(
+                Arrays.asList(
+                    new RsHasStatus(RsStatus.OK),
+                    new RsHasBody(new IsValidRegistration())
+                )
+            )
+        );
+    }
+
+    @Test
     void shouldFailPutRegistration() {
         final Response response = this.nuget.response(
             "PUT /base/registrations/newtonsoft.json/index.json",

--- a/src/test/java/com/artpie/nuget/http/metadata/RegistrationPageTest.java
+++ b/src/test/java/com/artpie/nuget/http/metadata/RegistrationPageTest.java
@@ -30,6 +30,7 @@ import com.artpie.nuget.PackageIdentity;
 import com.artpie.nuget.Repository;
 import com.artpie.nuget.Version;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -37,6 +38,8 @@ import javax.json.JsonObject;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.AllOf;
+import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import wtf.g4s8.hamcrest.json.JsonContains;
 import wtf.g4s8.hamcrest.json.JsonHas;
@@ -90,6 +93,28 @@ class RegistrationPageTest {
                                 .collect(Collectors.toList())
                         )
                     )
+                )
+            )
+        );
+    }
+
+    @Test
+    void shouldFailToGenerateJsonWhenEmpty() {
+        final String id = "Some.Lib";
+        final Throwable throwable = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new RegistrationPage(
+                new Repository(new BlockingStorage(new InMemoryStorage())),
+                new PackageId(id),
+                Collections.emptyList()
+            ).json()
+        );
+        MatcherAssert.assertThat(
+            throwable.getMessage(),
+            new AllOf<>(
+                Arrays.asList(
+                    new StringContains(true, "Registration page contains no versions"),
+                    new StringContains(false, id)
                 )
             )
         );


### PR DESCRIPTION
Part of #19 
Fixed bug with Registration resource crashing when no versions of package exist