### PR TITLE
#20 - Added HTTP multipart request parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.14.3</version>
+      <version>0.17</version>
     </dependency>
     <dependency>
       <groupId>javax.json</groupId>
@@ -87,7 +87,12 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.5</version>
+      <version>0.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/artpie/nuget/http/PackagePublish.java
+++ b/src/main/java/com/artpie/nuget/http/PackagePublish.java
@@ -24,6 +24,7 @@
 
 package com.artpie.nuget.http;
 
+import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
@@ -103,7 +104,7 @@ public final class PackagePublish implements Route {
             return connection -> CompletableFuture
                 .supplyAsync(() -> new Key.From(UUID.randomUUID().toString()))
                 .thenCompose(
-                    key -> this.storage.save(key, body).thenCompose(
+                    key -> this.storage.save(key, new Content.From(body)).thenCompose(
                         ignored -> {
                             RsStatus status;
                             try {

--- a/src/main/java/com/artpie/nuget/http/publish/Multipart.java
+++ b/src/main/java/com/artpie/nuget/http/publish/Multipart.java
@@ -1,0 +1,131 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artpie.nuget.http.publish;
+
+import com.artipie.asto.Concatenation;
+import com.artipie.asto.Content;
+import com.artipie.asto.Remaining;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.StreamSupport;
+import org.apache.commons.fileupload.MultipartStream;
+import org.apache.commons.fileupload.ParameterParser;
+import org.reactivestreams.Publisher;
+
+/**
+ * HTTP 'multipart/form-data' request.
+ *
+ * @since 0.1
+ */
+public final class Multipart {
+
+    /**
+     * Request headers.
+     */
+    private final Iterable<Map.Entry<String, String>> headers;
+
+    /**
+     * Request body.
+     */
+    private final Publisher<ByteBuffer> body;
+
+    /**
+     * Ctor.
+     *
+     * @param headers Request headers.
+     * @param body Request body.
+     */
+    public Multipart(
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        this.headers = headers;
+        this.body = body;
+    }
+
+    /**
+     * Read first part.
+     *
+     * @return First part content.
+     */
+    public Content first() {
+        return new Content.From(
+            new Concatenation(this.body)
+                .single()
+                .map(Remaining::new)
+                .map(Remaining::bytes)
+                .map(ByteArrayInputStream::new)
+                .map(
+                    input -> {
+                        final int buffer = 4096;
+                        final MultipartStream stream = new MultipartStream(
+                            input,
+                            this.boundary(),
+                            buffer,
+                            null
+                        );
+                        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                        try {
+                            if (!stream.skipPreamble()) {
+                                throw new IllegalStateException("Body has no parts");
+                            }
+                            stream.readHeaders();
+                            stream.readBodyData(bos);
+                        } catch (final IOException ex) {
+                            throw new IllegalStateException("Failed to read body as multipart", ex);
+                        }
+                        return ByteBuffer.wrap(bos.toByteArray());
+                    }
+                )
+                .toFlowable()
+        );
+    }
+
+    /**
+     * Reads boundary from headers.
+     *
+     * @return Boundary bytes.
+     */
+    private byte[] boundary() {
+        final String header = StreamSupport.stream(this.headers.spliterator(), false)
+            .filter(entry -> entry.getKey().equalsIgnoreCase("Content-Type"))
+            .map(Map.Entry::getValue)
+            .findFirst()
+            .orElseThrow(
+                () -> new IllegalStateException("Cannot find header \"Content-Type\"")
+            );
+        final ParameterParser parser = new ParameterParser();
+        parser.setLowerCaseNames(true);
+        final String boundary = Objects.requireNonNull(
+            parser.parse(header, ';').get("boundary"),
+            String.format("Boundary not specified: '%s'", header)
+        );
+        return boundary.getBytes(StandardCharsets.ISO_8859_1);
+    }
+}

--- a/src/main/java/com/artpie/nuget/http/publish/package-info.java
+++ b/src/main/java/com/artpie/nuget/http/publish/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * NuGet repository Package Publish service.
+ * See <a href="https://docs.microsoft.com/en-us/nuget/api/package-publish-resource">Push and Delete</a>
+ *
+ * @since 0.1
+ */
+package com.artpie.nuget.http.publish;

--- a/src/test/java/com/artpie/nuget/RepositoryHttpIT.java
+++ b/src/test/java/com/artpie/nuget/RepositoryHttpIT.java
@@ -27,7 +27,7 @@ package com.artpie.nuget;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
-import com.artipie.asto.fs.FileStorage;
+import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.vertx.VertxSliceServer;
 import com.artpie.nuget.http.NuGet;
 import com.google.common.collect.ImmutableList;
@@ -77,7 +77,7 @@ class RepositoryHttpIT {
 
     @BeforeEach
     void setUp() throws Exception {
-        this.storage = new FileStorage(this.temp.resolve("repo"));
+        this.storage = new InMemoryStorage();
         final int port = 8080;
         final String path = String.format("/%s", UUID.randomUUID().toString());
         final String base = String.format("http://localhost:%s%s", port, path);

--- a/src/test/java/com/artpie/nuget/RepositoryIT.java
+++ b/src/test/java/com/artpie/nuget/RepositoryIT.java
@@ -29,6 +29,7 @@ import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
 import com.google.common.collect.ImmutableList;
 import com.jcabi.log.Logger;
+import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -89,7 +90,9 @@ class RepositoryIT {
     }
 
     private void addPackage() throws Exception {
-        final BlockingStorage storage = new BlockingStorage(new FileStorage(this.repo));
+        final BlockingStorage storage = new BlockingStorage(
+            new FileStorage(this.repo, Vertx.vertx().fileSystem())
+        );
         final Key.From source = new Key.From("package.zip");
         storage.save(source, new NewtonJsonResource("newtonsoft.json.12.0.3.nupkg").bytes());
         final Repository repository = new Repository(storage);

--- a/src/test/java/com/artpie/nuget/http/publish/MultipartTest.java
+++ b/src/test/java/com/artpie/nuget/http/publish/MultipartTest.java
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artpie.nuget.http.publish;
+
+import com.artipie.asto.Concatenation;
+import com.artipie.asto.Remaining;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.cactoos.map.MapEntry;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Multipart}.
+ *
+ * @since 0.1
+ */
+class MultipartTest {
+
+    @Test
+    void shouldReadFirstPart() {
+        final Multipart multipart = new Multipart(
+            Collections.singleton(
+                new MapEntry<>(
+                    "Content-Type",
+                    "multipart/form-data; boundary=\"simple boundary\""
+                )
+            ),
+            Flowable.just(
+                ByteBuffer.wrap(
+                    String.join(
+                        "",
+                        "--simple boundary\r\n",
+                        "Some-Header: info\r\n",
+                        "\r\n",
+                        "data\r\n",
+                        "--simple boundary--"
+                    ).getBytes()
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            new Remaining(new Concatenation(multipart.first()).single().blockingGet()).bytes(),
+            new IsEqual<>("data".getBytes())
+        );
+    }
+}

--- a/src/test/java/com/artpie/nuget/http/publish/package-info.java
+++ b/src/test/java/com/artpie/nuget/http/publish/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tests for NuGet repository Package Publish service related classes.
+ *
+ * @since 0.1
+ */
+package com.artpie.nuget.http.publish;


### PR DESCRIPTION
Part of #20 
Added class for multipart request parsing. It will be needed  to implement publishing a package (it comes as first part in a multipart request)