### PR TITLE
#84 - Basic auth support for package publish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.9.4</version>
+      <version>0.9.5</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/artipie/nuget/http/NuGet.java
+++ b/src/main/java/com/artipie/nuget/http/NuGet.java
@@ -62,6 +62,16 @@ import org.reactivestreams.Publisher;
 public final class NuGet implements Slice {
 
     /**
+     * Read permission name.
+     */
+    public static final String READ = "read";
+
+    /**
+     * Write permission name.
+     */
+    public static final String WRITE = "write";
+
+    /**
      * Base URL.
      */
     private final URL url;
@@ -186,9 +196,24 @@ public final class NuGet implements Slice {
                     new RouteService(this.url, content, "PackageBaseAddress/3.0.0")
                 )
             ),
-            publish,
-            new BasicAuthRoute(content, new Permission.ByName("read", this.perms), this.users),
+            this.auth(publish, NuGet.WRITE),
+            this.auth(content, NuGet.READ),
             metadata
+        );
+    }
+
+    /**
+     * Create route supporting basic authentication.
+     *
+     * @param route Route requiring authentication.
+     * @param permission Permission name.
+     * @return Authenticated route.
+     */
+    private Route auth(final Route route, final String permission) {
+        return new BasicAuthRoute(
+            route,
+            new Permission.ByName(permission, this.perms),
+            this.users
         );
     }
 }

--- a/src/test/java/com/artipie/nuget/http/TestAuthentication.java
+++ b/src/test/java/com/artipie/nuget/http/TestAuthentication.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.nuget.http;
+
+import com.artipie.http.Headers;
+import com.artipie.http.auth.Authentication;
+import com.artipie.http.rs.Header;
+import java.util.Optional;
+
+/**
+ * Single user basic authentication for usage in tests.
+ *
+ * @since 0.2
+ */
+public final class TestAuthentication implements Authentication {
+
+    /**
+     * User name.
+     */
+    public static final String USERNAME = "Aladdin";
+
+    /**
+     * Basic authentication header.
+     */
+    public static final Header HEADER = new Header(
+        "Authorization",
+        "Basic QWxhZGRpbjpPcGVuU2VzYW1l"
+    );
+
+    /**
+     * Basic authentication headers.
+     */
+    public static final Headers HEADERS = new Headers.From(TestAuthentication.HEADER);
+
+    @Override
+    public Optional<String> user(final String username, final String password) {
+        final Optional<String> auth;
+        if (USERNAME.equals(username) && "OpenSesame".equals(password)) {
+            auth = Optional.of(username);
+        } else {
+            auth = Optional.empty();
+        }
+        return auth;
+    }
+}

--- a/src/test/java/com/artipie/nuget/http/TestAuthentication.java
+++ b/src/test/java/com/artipie/nuget/http/TestAuthentication.java
@@ -23,10 +23,13 @@
  */
 package com.artipie.nuget.http;
 
-import com.artipie.http.Headers;
 import com.artipie.http.auth.Authentication;
-import com.artipie.http.rs.Header;
+import com.artipie.http.auth.BasicAuthorizationHeader;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 
 /**
  * Single user basic authentication for usage in tests.
@@ -41,26 +44,73 @@ public final class TestAuthentication implements Authentication {
     public static final String USERNAME = "Aladdin";
 
     /**
-     * Basic authentication header.
+     * Password.
      */
-    public static final Header HEADER = new Header(
-        "Authorization",
-        "Basic QWxhZGRpbjpPcGVuU2VzYW1l"
-    );
-
-    /**
-     * Basic authentication headers.
-     */
-    public static final Headers HEADERS = new Headers.From(TestAuthentication.HEADER);
+    private static final String PASSWORD = "OpenSesame";
 
     @Override
     public Optional<String> user(final String username, final String password) {
         final Optional<String> auth;
-        if (USERNAME.equals(username) && "OpenSesame".equals(password)) {
+        if (USERNAME.equals(username) && PASSWORD.equals(password)) {
             auth = Optional.of(username);
         } else {
             auth = Optional.empty();
         }
         return auth;
+    }
+
+    /**
+     * Basic authentication header.
+     *
+     * @since 0.2
+     */
+    public static final class Header extends com.artipie.http.rs.Header.Wrap {
+
+        /**
+         * Ctor.
+         */
+        public Header() {
+            super(
+                new BasicAuthorizationHeader(
+                    TestAuthentication.USERNAME,
+                    TestAuthentication.PASSWORD
+                )
+            );
+        }
+    }
+
+    /**
+     * Basic authentication headers.
+     *
+     * @since 0.2
+     */
+    public static final class Headers implements com.artipie.http.Headers {
+
+        /**
+         * Origin headers.
+         */
+        private final com.artipie.http.Headers origin;
+
+        /**
+         * Ctor.
+         */
+        public Headers() {
+            this.origin = new Headers.From(new Header());
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, String>> iterator() {
+            return this.origin.iterator();
+        }
+
+        @Override
+        public void forEach(final Consumer<? super Map.Entry<String, String>> action) {
+            this.origin.forEach(action);
+        }
+
+        @Override
+        public Spliterator<Map.Entry<String, String>> spliterator() {
+            return this.origin.spliterator();
+        }
     }
 }

--- a/src/test/java/com/artipie/nuget/http/TestPermissions.java
+++ b/src/test/java/com/artipie/nuget/http/TestPermissions.java
@@ -1,0 +1,60 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.nuget.http;
+
+import com.artipie.http.auth.Permissions;
+
+/**
+ * Single user with single action allowed permissions for usage in tests.
+ *
+ * @since 0.2
+ */
+public final class TestPermissions implements Permissions {
+
+    /**
+     * User name.
+     */
+    private final String username;
+
+    /**
+     * Allowed action.
+     */
+    private final String action;
+
+    /**
+     * Ctor.
+     *
+     * @param username User name.
+     * @param allowed Allowed action.
+     */
+    public TestPermissions(final String username, final String allowed) {
+        this.username = username;
+        this.action = allowed;
+    }
+
+    @Override
+    public boolean allowed(final String name, final String act) {
+        return this.username.equals(name) && this.action.equals(act);
+    }
+}

--- a/src/test/java/com/artipie/nuget/http/publish/NuGetPackagePublishTest.java
+++ b/src/test/java/com/artipie/nuget/http/publish/NuGetPackagePublishTest.java
@@ -26,9 +26,13 @@ package com.artipie.nuget.http.publish;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
+import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rs.Header;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.nuget.http.NuGet;
+import com.artipie.nuget.http.TestAuthentication;
 import com.google.common.io.Resources;
 import io.reactivex.Flowable;
 import java.io.ByteArrayOutputStream;
@@ -39,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -61,7 +66,11 @@ class NuGetPackagePublishTest {
         this.nuget = new NuGet(
             new URL("http://localhost"),
             "/base",
-            new InMemoryStorage()
+            new InMemoryStorage(),
+            (name, action) -> {
+                return TestAuthentication.USERNAME.equals(name) && NuGet.WRITE.equals(action);
+            },
+            new TestAuthentication()
         );
     }
 
@@ -109,10 +118,25 @@ class NuGetPackagePublishTest {
     void shouldFailGetPackagePublish() {
         final Response response = this.nuget.response(
             "GET /base/package HTTP/1.1",
-            Collections.emptyList(),
+            TestAuthentication.HEADERS,
             Flowable.empty()
         );
         MatcherAssert.assertThat(response, new RsHasStatus(RsStatus.METHOD_NOT_ALLOWED));
+    }
+
+    @Test
+    void shouldFailPutPackageWithoutAuth() {
+        MatcherAssert.assertThat(
+            this.nuget.response(
+                "PUT /base/package HTTP/1.1",
+                Headers.EMPTY,
+                Flowable.fromArray(ByteBuffer.wrap("data".getBytes()))
+            ),
+            Matchers.allOf(
+                new RsHasStatus(RsStatus.UNAUTHORIZED),
+                new RsHasHeaders(new Header("WWW-Authenticate", "Basic"))
+            )
+        );
     }
 
     private Response putPackage(final byte[] pack) throws Exception {
@@ -122,9 +146,10 @@ class NuGetPackagePublishTest {
         final ByteArrayOutputStream sink = new ByteArrayOutputStream();
         entity.writeTo(sink);
         return this.nuget.response(
-            "PUT /base/package HTTP/1.1",
+            new RequestLine("PUT", "/base/package", "HTTP/1.1").toString(),
             new Headers.From(
-                "Content-Type", entity.getContentType().getValue()
+                TestAuthentication.HEADER,
+                new Header("Content-Type", entity.getContentType().getValue())
             ),
             Flowable.fromArray(ByteBuffer.wrap(sink.toByteArray()))
         );

--- a/src/test/java/com/artipie/nuget/http/publish/NuGetPackagePublishTest.java
+++ b/src/test/java/com/artipie/nuget/http/publish/NuGetPackagePublishTest.java
@@ -26,13 +26,14 @@ package com.artipie.nuget.http.publish;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
-import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.ResponseMatcher;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rs.Header;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.nuget.http.NuGet;
 import com.artipie.nuget.http.TestAuthentication;
+import com.artipie.nuget.http.TestPermissions;
 import com.google.common.io.Resources;
 import io.reactivex.Flowable;
 import java.io.ByteArrayOutputStream;
@@ -43,7 +44,6 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -67,9 +67,7 @@ class NuGetPackagePublishTest {
             new URL("http://localhost"),
             "/base",
             new InMemoryStorage(),
-            (name, action) -> {
-                return TestAuthentication.USERNAME.equals(name) && NuGet.WRITE.equals(action);
-            },
+            new TestPermissions(TestAuthentication.USERNAME, NuGet.WRITE),
             new TestAuthentication()
         );
     }
@@ -118,7 +116,7 @@ class NuGetPackagePublishTest {
     void shouldFailGetPackagePublish() {
         final Response response = this.nuget.response(
             "GET /base/package HTTP/1.1",
-            TestAuthentication.HEADERS,
+            new TestAuthentication.Headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(response, new RsHasStatus(RsStatus.METHOD_NOT_ALLOWED));
@@ -132,10 +130,7 @@ class NuGetPackagePublishTest {
                 Headers.EMPTY,
                 Flowable.fromArray(ByteBuffer.wrap("data".getBytes()))
             ),
-            Matchers.allOf(
-                new RsHasStatus(RsStatus.UNAUTHORIZED),
-                new RsHasHeaders(new Header("WWW-Authenticate", "Basic"))
-            )
+            new ResponseMatcher(RsStatus.UNAUTHORIZED, new Header("WWW-Authenticate", "Basic"))
         );
     }
 
@@ -148,7 +143,7 @@ class NuGetPackagePublishTest {
         return this.nuget.response(
             new RequestLine("PUT", "/base/package", "HTTP/1.1").toString(),
             new Headers.From(
-                TestAuthentication.HEADER,
+                new TestAuthentication.Header(),
                 new Header("Content-Type", entity.getContentType().getValue())
             ),
             Flowable.fromArray(ByteBuffer.wrap(sink.toByteArray()))
@@ -160,4 +155,5 @@ class NuGetPackagePublishTest {
             .getResource("newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg");
         return Resources.toByteArray(resource);
     }
+
 }


### PR DESCRIPTION
Part of #84 
Added support for basic auth in publish service. Write permission required.