### PR TITLE
#113 - Repository accepts async Storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.3.9</version>
+    <version>0.4</version>
   </parent>
   <artifactId>nuget-adapter</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -70,7 +70,6 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.26</version>
     </dependency>
     <dependency>
       <groupId>javax.json</groupId>
@@ -85,7 +84,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.15.7</version>
+      <version>0.15.8</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/artipie/nuget/http/NuGet.java
+++ b/src/main/java/com/artipie/nuget/http/NuGet.java
@@ -24,7 +24,6 @@
 package com.artipie.nuget.http;
 
 import com.artipie.asto.Storage;
-import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
@@ -168,7 +167,7 @@ public final class NuGet implements Slice {
         final PackagePublish publish = new PackagePublish(this.storage);
         final PackageContent content = new PackageContent(this.url, this.storage);
         final PackageMetadata metadata = new PackageMetadata(
-            new Repository(new BlockingStorage(this.storage)),
+            new Repository(this.storage),
             content
         );
         return new RoutingResource(

--- a/src/main/java/com/artipie/nuget/http/publish/PackagePublish.java
+++ b/src/main/java/com/artipie/nuget/http/publish/PackagePublish.java
@@ -26,7 +26,6 @@ package com.artipie.nuget.http.publish;
 
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
-import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
 import com.artipie.http.async.AsyncResponse;
@@ -116,9 +115,7 @@ public final class PackagePublish implements Route {
                                 ignored -> {
                                     RsStatus status;
                                     try {
-                                        new Repository(
-                                            new BlockingStorage(this.storage)
-                                        ).add(key);
+                                        new Repository(this.storage).add(key);
                                         status = RsStatus.CREATED;
                                     } catch (final IOException | InterruptedException ex) {
                                         throw new IllegalStateException(ex);

--- a/src/test/java/com/artipie/nuget/RepositoryIT.java
+++ b/src/test/java/com/artipie/nuget/RepositoryIT.java
@@ -25,6 +25,7 @@
 package com.artipie.nuget;
 
 import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.fs.FileStorage;
 import com.google.common.collect.ImmutableList;
@@ -89,9 +90,12 @@ class RepositoryIT {
     }
 
     private void addPackage() throws Exception {
-        final BlockingStorage storage = new BlockingStorage(new FileStorage(this.repo));
+        final Storage storage = new FileStorage(this.repo);
         final Key.From source = new Key.From("package.zip");
-        storage.save(source, new NewtonJsonResource("newtonsoft.json.12.0.3.nupkg").bytes());
+        new BlockingStorage(storage).save(
+            source,
+            new NewtonJsonResource("newtonsoft.json.12.0.3.nupkg").bytes()
+        );
         final Repository repository = new Repository(storage);
         repository.add(source);
     }

--- a/src/test/java/com/artipie/nuget/RepositoryTest.java
+++ b/src/test/java/com/artipie/nuget/RepositoryTest.java
@@ -62,8 +62,9 @@ class RepositoryTest {
 
     @BeforeEach
     void init() {
-        this.storage = new BlockingStorage(new InMemoryStorage());
-        this.repository = new Repository(this.storage);
+        final InMemoryStorage asto = new InMemoryStorage();
+        this.storage = new BlockingStorage(asto);
+        this.repository = new Repository(asto);
     }
 
     @Test

--- a/src/test/java/com/artipie/nuget/http/metadata/RegistrationPageTest.java
+++ b/src/test/java/com/artipie/nuget/http/metadata/RegistrationPageTest.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.nuget.http.metadata;
 
+import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.nuget.PackageId;
@@ -57,7 +58,7 @@ class RegistrationPageTest {
 
     @Test
     void shouldGenerateJson() throws Exception {
-        final BlockingStorage storage = new BlockingStorage(new InMemoryStorage());
+        final Storage storage = new InMemoryStorage();
         final Repository repository = new Repository(storage);
         final PackageId id = new PackageId("My.Lib");
         final String lower = "0.1";
@@ -66,7 +67,7 @@ class RegistrationPageTest {
             .map(Version::new)
             .collect(Collectors.toList());
         for (final Version version : versions) {
-            storage.save(
+            new BlockingStorage(storage).save(
                 new PackageIdentity(id, version).nuspecKey(),
                 String.join(
                     "",
@@ -106,7 +107,7 @@ class RegistrationPageTest {
         final Throwable throwable = Assertions.assertThrows(
             IllegalStateException.class,
             () -> new RegistrationPage(
-                new Repository(new BlockingStorage(new InMemoryStorage())),
+                new Repository(new InMemoryStorage()),
                 RegistrationPageTest::contentUrl,
                 new PackageId(id),
                 Collections.emptyList()


### PR DESCRIPTION
Part of #113 
`Repository` changed to accept `Storage` instead of `BlockingStorage` to use it's `exclusivly` method later.
Dependencies updated to up-to-date versions.