### PR TITLE
#117 - Repository.versions made async

### DIFF
--- a/src/main/java/com/artipie/nuget/http/metadata/CompletionStages.java
+++ b/src/main/java/com/artipie/nuget/http/metadata/CompletionStages.java
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.nuget.http.metadata;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+/**
+ * Collection of completion stages that all can be combined into single one.
+ *
+ * @param <T> Completion stages type.
+ * @since 0.4
+ */
+final class CompletionStages<T> {
+
+    /**
+     * Completion stages.
+     */
+    private final Collection<CompletionStage<T>> stages;
+
+    /**
+     * Ctor.
+     *
+     * @param stages Completion stages.
+     */
+    CompletionStages(final Collection<CompletionStage<T>> stages) {
+        this.stages = stages;
+    }
+
+    /**
+     * Combine original stages into single one that completes when all stages are complete.
+     *
+     * @return Combined completion stages.
+     */
+    public CompletionStage<Collection<T>> all() {
+        final List<CompletableFuture<T>> futures = this.stages.stream()
+            .map(CompletionStage::toCompletableFuture)
+            .collect(Collectors.toList());
+        return CompletableFuture.allOf(
+            futures.stream().toArray(CompletableFuture[]::new)
+        ).thenApply(
+            nothing -> futures.stream().map(CompletableFuture::join).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/com/artipie/nuget/http/metadata/CompletionStages.java
+++ b/src/main/java/com/artipie/nuget/http/metadata/CompletionStages.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Collection of completion stages that all can be combined into single one.
@@ -41,6 +42,15 @@ final class CompletionStages<T> {
      * Completion stages.
      */
     private final Collection<CompletionStage<T>> stages;
+
+    /**
+     * Ctor.
+     *
+     * @param stages Completion stages.
+     */
+    CompletionStages(final Stream<CompletionStage<T>> stages) {
+        this(stages.collect(Collectors.toList()));
+    }
 
     /**
      * Ctor.

--- a/src/main/java/com/artipie/nuget/http/metadata/Registration.java
+++ b/src/main/java/com/artipie/nuget/http/metadata/Registration.java
@@ -30,7 +30,7 @@ import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithStatus;
 import com.artipie.nuget.PackageId;
 import com.artipie.nuget.Repository;
-import com.artipie.nuget.Version;
+import com.artipie.nuget.Versions;
 import com.artipie.nuget.http.Resource;
 import com.artipie.nuget.http.RsWithBodyNoHeaders;
 import java.io.ByteArrayOutputStream;
@@ -39,7 +39,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
@@ -88,20 +88,16 @@ class Registration implements Resource {
 
     @Override
     public Response get(final Headers headers) {
-        final List<CompletableFuture<JsonObject>> pages;
-        try {
-            pages = this.pages().stream()
-                .map(page -> page.json().toCompletableFuture())
-                .collect(Collectors.toList());
-        } catch (final InterruptedException ex) {
-            throw new IllegalStateException(ex);
-        }
         return new AsyncResponse(
-            CompletableFuture.allOf(pages.stream().toArray(CompletableFuture[]::new)).thenApply(
-                nothing -> {
+            this.pages().thenCompose(
+                pages -> new CompletionStages<>(
+                    pages.stream().map(RegistrationPage::json).collect(Collectors.toList())
+                ).all()
+            ).thenApply(
+                pages -> {
                     final JsonArrayBuilder items = Json.createArrayBuilder();
-                    for (final CompletableFuture<JsonObject> page : pages) {
-                        items.add(page.join());
+                    for (final JsonObject page : pages) {
+                        items.add(page);
                     }
                     final JsonObject json = Json.createObjectBuilder()
                         .add("count", pages.size())
@@ -134,18 +130,20 @@ class Registration implements Resource {
      * Enumerate version pages.
      *
      * @return List of pages.
-     * @throws InterruptedException In case executing thread has been interrupted.
      */
-    private List<RegistrationPage> pages() throws InterruptedException {
-        final List<Version> versions = this.repository.versions(this.id).all();
-        final List<RegistrationPage> pages;
-        if (versions.isEmpty()) {
-            pages = Collections.emptyList();
-        } else {
-            pages = Collections.singletonList(
-                new RegistrationPage(this.repository, this.content, this.id, versions)
-            );
-        }
-        return pages;
+    private CompletionStage<List<RegistrationPage>> pages() {
+        return this.repository.versions(this.id).thenApply(Versions::all).thenApply(
+            versions -> {
+                final List<RegistrationPage> pages;
+                if (versions.isEmpty()) {
+                    pages = Collections.emptyList();
+                } else {
+                    pages = Collections.singletonList(
+                        new RegistrationPage(this.repository, this.content, this.id, versions)
+                    );
+                }
+                return pages;
+            }
+        );
     }
 }

--- a/src/main/java/com/artipie/nuget/http/metadata/Registration.java
+++ b/src/main/java/com/artipie/nuget/http/metadata/Registration.java
@@ -40,7 +40,6 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
@@ -90,9 +89,7 @@ class Registration implements Resource {
     public Response get(final Headers headers) {
         return new AsyncResponse(
             this.pages().thenCompose(
-                pages -> new CompletionStages<>(
-                    pages.stream().map(RegistrationPage::json).collect(Collectors.toList())
-                ).all()
+                pages -> new CompletionStages<>(pages.stream().map(RegistrationPage::json)).all()
             ).thenApply(
                 pages -> {
                     final JsonArrayBuilder items = Json.createArrayBuilder();

--- a/src/main/java/com/artipie/nuget/http/metadata/RegistrationPage.java
+++ b/src/main/java/com/artipie/nuget/http/metadata/RegistrationPage.java
@@ -29,7 +29,6 @@ import com.artipie.nuget.Repository;
 import com.artipie.nuget.Version;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
@@ -102,7 +101,7 @@ final class RegistrationPage {
         return new CompletionStages<>(
             this.versions.stream().map(
                 version -> this.leaf(new PackageIdentity(this.id, version))
-            ).collect(Collectors.toList())
+            )
         ).all().thenApply(
             leafs -> {
                 final JsonArrayBuilder items = Json.createArrayBuilder();

--- a/src/test/java/com/artipie/nuget/RepositoryTest.java
+++ b/src/test/java/com/artipie/nuget/RepositoryTest.java
@@ -146,7 +146,7 @@ class RepositoryTest {
             .getBytes(StandardCharsets.US_ASCII);
         final PackageId foo = new PackageId("Foo");
         this.storage.save(foo.versionsKey(), bytes);
-        final Versions versions = this.repository.versions(foo);
+        final Versions versions = this.repository.versions(foo).toCompletableFuture().join();
         final Key.From bar = new Key.From("bar");
         versions.save(this.asto, bar).toCompletableFuture().join();
         MatcherAssert.assertThat(
@@ -159,7 +159,7 @@ class RepositoryTest {
     @Test
     void shouldGetEmptyPackageVersionsWhenNonePresent() throws Exception {
         final PackageId pack = new PackageId("MyLib");
-        final Versions versions = this.repository.versions(pack);
+        final Versions versions = this.repository.versions(pack).toCompletableFuture().join();
         final Key.From sink = new Key.From("sink");
         versions.save(this.asto, sink).toCompletableFuture().join();
         MatcherAssert.assertThat(


### PR DESCRIPTION
Part of #117 
`Repository.versions` made async
`CompletionStages` extracted for combining multiple stages into single one
